### PR TITLE
Initial

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,21 +1,16 @@
-version: 2
-jobs:
-  build:
-    machine: true
-    steps:
-    - checkout
+version: 2.1
+orbs:
+  architect: giantswarm/architect@0.8.3
 
-    - run:
-        name: Install architect
-        command: |
-          wget -q $(curl -sS -H "Authorization: token $RELEASE_TOKEN" https://api.github.com/repos/giantswarm/architect/releases/latest | grep browser_download_url | head -n 1 | cut -d '"' -f 4)
-          chmod +x ./architect
-          ./architect version
-    - run:
-        name: Build using architect
-        command: ./architect build
-    - deploy:
-        command: |
-          if [ "${CIRCLE_BRANCH}" == "master" ]; then
-            ./architect deploy
-          fi
+workflows:
+  build:
+    jobs:
+      - architect/push-to-app-catalog:
+          name: push-to-default-app-catalog
+          app_catalog: "default-catalog"
+          app_catalog_test: "default-test-catalog"
+          chart: "test-app"
+          filters:
+            # Trigger the job also on git tag.
+            tags:
+              only: /^v.*/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,4 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-[Unreleased]: https://github.com/giantswarm/REPOSITORY_NAME/tree/master
+### Added 
+
+- Add initial version.
+
+[Unreleased]: https://github.com/giantswarm/test-app/tree/master

--- a/README.md
+++ b/README.md
@@ -1,33 +1,5 @@
-<!--
+[![CircleCI](https://circleci.com/gh/giantswarm/test-app.svg?style=shield)](https://circleci.com/gh/giantswarm/test-app)
 
-    TODO:
+# test-app
 
-    - Add the project to the CircleCI:
-      https://circleci.com/setup-project/gh/giantswarm/REPOSITORY_NAME
-
-    - Import RELEASE_TOKEN variable from template repository for the builds:
-      https://circleci.com/gh/giantswarm/REPOSITORY_NAME/edit#env-vars
-
-    - Change the badge (with style=shield):
-      https://circleci.com/gh/giantswarm/REPOSITORY_NAME/edit#badges
-      If this is a private repository token with scope `status` will be needed.
-
-    - Run `devctl replace -i "REPOSITORY_NAME" "$(basename $(git rev-parse --show-toplevel))" *.md`
-      and commit your changes.
-
-    - If the repository is public consider adding godoc badge. This should be
-      the first badge separated with a single space.
-      [![GoDoc](https://godoc.org/github.com/giantswarm/REPOSITORY_NAME?status.svg)](http://godoc.org/github.com/giantswarm/REPOSITORY_NAME)
-
--->
-[![CircleCI](https://circleci.com/gh/giantswarm/template.svg?style=shield&circle-token=cbabd7d13186f190fca813db4f0c732b026f5f6c)](https://circleci.com/gh/giantswarm/template)
-
-# REPOSITORY_NAME
-
-This is a template repository containing some basic files every repository
-needs.
-
-To use it just hit `Use this template` button or [this
-link][generate].
-
-[generate]: https://github.com/giantswarm/template/generate
+A test app packaged as a Helm chart for testing App Catalog functionality.

--- a/README.md
+++ b/README.md
@@ -3,4 +3,3 @@
 # test-app
 
 A test app packaged as a Helm chart for testing App Catalog functionality.
-

--- a/README.md
+++ b/README.md
@@ -3,3 +3,4 @@
 # test-app
 
 A test app packaged as a Helm chart for testing App Catalog functionality.
+

--- a/helm/test-app/Chart.yaml
+++ b/helm/test-app/Chart.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+appVersion: v1.8.0
+description: A Helm chart for a test app
+home: https://github.com/giantswarm/kubernetes-test-app
+name: kubernetes-test-app-chart
+# Depicts the version used for CI. Will get replaced by the version,
+# which is specified in the VERSION file in the project root.
+version: 0.1.0-[[ .SHA ]]

--- a/helm/test-app/Chart.yaml
+++ b/helm/test-app/Chart.yaml
@@ -1,8 +1,6 @@
 apiVersion: v1
 appVersion: v1.8.0
 description: A Helm chart for a test app
-home: https://github.com/giantswarm/kubernetes-test-app
-name: kubernetes-test-app-chart
-# Depicts the version used for CI. Will get replaced by the version,
-# which is specified in the VERSION file in the project root.
-version: 0.1.0-[[ .SHA ]]
+home: https://github.com/giantswarm/test-app
+name: test-app
+version: [[ .Version ]]

--- a/helm/test-app/templates/deployment.yaml
+++ b/helm/test-app/templates/deployment.yaml
@@ -1,0 +1,40 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ .Values.name }}
+  namespace: {{ .Values.namespace }}
+  labels:
+    app: {{ .Values.name }}
+    giantswarm.io/service-type: "managed"
+spec:
+  replicas: {{ .Values.replicas }}
+  selector:
+    matchLabels:
+      app: {{ .Values.name }}
+  template:
+    metadata:
+      labels:
+        app: {{ .Values.name }}
+        giantswarm.io/service-type: "managed"
+    spec:
+      containers:
+      - name: {{ .Values.name }}
+        image: "{{ .Values.image.registry }}/{{ .Values.image.name }}:{{ .Values.image.tag }}"
+        args:
+        - '--port={{ .Values.port }}'
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: {{ .Values.port }}
+          initialDelaySeconds: 5
+          timeoutSeconds: 5
+        readinessProbe:
+          httpGet:
+            path: /healthz
+            port: {{ .Values.port }}
+          initialDelaySeconds: 5
+          timeoutSeconds: 5
+        resources:
+{{ toYaml .Values.resources | indent 10 }}
+      serviceAccountName: {{ .Values.name }}
+      hostNetwork: true

--- a/helm/test-app/templates/psp.yaml
+++ b/helm/test-app/templates/psp.yaml
@@ -1,0 +1,26 @@
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: {{ .Values.name }}
+  labels:
+    app: {{ .Values.name }}
+    giantswarm.io/service-type: "managed"
+spec:
+  allowPrivilegeEscalation: true
+  fsGroup:
+    rule: RunAsAny
+  privileged: true
+  runAsUser:
+    rule: RunAsAny
+  seLinux:
+    rule: RunAsAny
+  supplementalGroups:
+    rule: RunAsAny
+  volumes:
+  - '*'
+  hostPID: true
+  hostIPC: true
+  hostNetwork: true
+  hostPorts:
+  - min: 1
+    max: 65536

--- a/helm/test-app/templates/rbac.yaml
+++ b/helm/test-app/templates/rbac.yaml
@@ -1,0 +1,82 @@
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ .Values.name }}
+  labels:
+    app: {{ .Values.name }}
+    giantswarm.io/service-type: "managed"
+subjects:
+- kind: ServiceAccount
+  name: {{ .Values.name }}
+  namespace: {{ .Values.namespace }}
+roleRef:
+  kind: ClusterRole
+  name: {{ .Values.name }}
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ .Values.name }}
+  labels:
+    app: {{ .Values.name }}
+    giantswarm.io/service-type: "managed"
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  - pods
+  - services
+  - resourcequotas
+  - replicationcontrollers
+  - limitranges
+  - persistentvolumeclaims
+  - persistentvolumes
+  - namespaces
+  - endpoints
+  - secrets
+  - configmaps
+  verbs:
+  - list
+  - watch
+- apiGroups:
+  - extensions
+  resources:
+  - daemonsets
+  - deployments
+  - replicasets
+  verbs:
+  - list
+  - watch
+- apiGroups:
+  - apps
+  resources:
+  - statefulsets
+  verbs:
+  - list
+  - watch
+- apiGroups:
+  - batch
+  resources:
+  - cronjobs
+  - jobs
+  verbs:
+  - list
+  - watch
+- apiGroups:
+  - extensions
+  resources:
+  - podsecuritypolicies
+  verbs:
+  - use
+  resourceNames:
+  - {{ .Values.name }}
+- apiGroups:
+  - autoscaling
+  attributeRestrictions: null
+  resources:
+  - horizontalpodautoscalers
+  verbs:
+  - list
+  - watch

--- a/helm/test-app/templates/service-account.yaml
+++ b/helm/test-app/templates/service-account.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Values.name }}
+  namespace: {{ .Values.namespace }}
+  labels:
+    app: {{ .Values.name }}
+    giantswarm.io/service-type: "managed"

--- a/helm/test-app/templates/service.yaml
+++ b/helm/test-app/templates/service.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Values.name }}
+  namespace: {{ .Values.namespace }}
+  labels:
+    app: {{ .Values.name }}
+    giantswarm.io/service-type: "managed"
+  annotations:
+    prometheus.io/scrape: "true"
+    prometheus.io/scheme: "http"
+spec:
+  ports:
+  - port: {{ .Values.port }}
+    name: {{ .Values.portName }}
+  selector:
+    app: {{ .Values.name }}

--- a/helm/test-app/templates/test/test-runner.yaml
+++ b/helm/test-app/templates/test/test-runner.yaml
@@ -1,9 +1,9 @@
-apiVersion: v1
-kind: Pod
+apiVersion: batch/v1
+kind: Job
 metadata:
   name: {{ .Values.name }}-test
   annotations:
-    "helm.sh/hook": test-success
+    "helm.sh/hook": test
 spec:
   initContainers:
   # Bash automated testing systen

--- a/helm/test-app/templates/test/test-runner.yaml
+++ b/helm/test-app/templates/test/test-runner.yaml
@@ -1,0 +1,40 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: {{ .Values.name }}-test
+  annotations:
+    "helm.sh/hook": test-success
+spec:
+  initContainers:
+  # Bash automated testing systen
+  # https://github.com/bats-core/bats-core
+  - name: test-framework
+    image: quay.io/giantswarm/bats:0.4.0
+    command:
+    - "bash"
+    - "-c"
+    - |
+      set -ex
+      # copy bats to tools dir
+      cp -R /usr/local/libexec/ /tools/bats/
+    volumeMounts:
+    - mountPath: /tools
+      name: tools
+  containers:
+  - name: {{ .Values.name }}-test
+    image: "{{ .Values.test.image.registry }}/{{ .Values.test.image.name }}:{{ .Values.test.image.tag }}"
+    imagePullPolicy: IfNotPresent
+    command: ["/tools/bats/bats", "-t", "/tests/run.sh"]
+    volumeMounts:
+    - mountPath: /tests
+      name: tests
+      readOnly: true
+    - mountPath: /tools
+      name: tools
+  volumes:
+  - name: tests
+    configMap:
+      name: {{ .Values.name }}-tests
+  - name: tools
+    emptyDir: {}
+  restartPolicy: Never

--- a/helm/test-app/templates/test/tests.yaml
+++ b/helm/test-app/templates/test/tests.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Values.name }}-tests
+data:
+  run.sh: |-
+    @test "Testing metrics are up" {
+        curl --connect-timeout 10 --retry 12 --retry-delay 10 {{ .Values.name }}.{{ .Values.namespace }}:{{ .Values.port }}/metrics | \
+        grep kube_service_created.*default.*kubernetes.*1
+    }

--- a/helm/test-app/values.yaml
+++ b/helm/test-app/values.yaml
@@ -1,0 +1,26 @@
+name: test-app
+namespace: kube-system
+port: 10301
+portName: metrics
+
+replicas: 1
+
+image:
+  registry: quay.io
+  name: giantswarm/kube-state-metrics
+  # when updating tag make sure to also keep appVersion in Chart.yaml in sync
+  tag: v1.9.2
+
+resources:
+  limits:
+    cpu: 100m
+    memory: 300Mi
+  requests:
+    cpu: 100m
+    memory: 300Mi
+
+test:
+  image:
+    registry: quay.io
+    name: giantswarm/alpine-testing
+    tag: 0.1.1


### PR DESCRIPTION
Towards giantswarm/roadmap#30

This test-app is used in the chart-operator integration tests. 

It replaces https://github.com/giantswarm/kubernetes-test-app and pushes to the default catalog rather than the sample catalog which we want to retire.

## Checklist

- [x] Update changelog in CHANGELOG.md.
