### PR TITLE
Remove attributeRestrictions from RBAC manifest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Removed
+
+- Remove `attributeRestrictions` from RBAC manifest
+
 ## [1.0.0] - 2024-11-06
 
 ### Changed

--- a/helm/test-app/templates/rbac.yaml
+++ b/helm/test-app/templates/rbac.yaml
@@ -66,7 +66,6 @@ rules:
   - watch
 - apiGroups:
   - autoscaling
-  attributeRestrictions: null
   resources:
   - horizontalpodautoscalers
   verbs:


### PR DESCRIPTION
We get errors in CI like

> "Warning: unknown field \"rules[4].attributeRestrictions\""

(example: https://app.circleci.com/pipelines/github/giantswarm/helmclient/2975/workflows/09ec6a2c-05f8-4b86-bdbe-e7ff74255cc7/jobs/9683)

The field is no longer supported in rbac.authorization.k8s.io/v1

## Checklist

- [x] Update changelog in CHANGELOG.md.
